### PR TITLE
Correct price conversion

### DIFF
--- a/fetchprices.js
+++ b/fetchprices.js
@@ -130,7 +130,7 @@ function fetchData(fetchDate) {
           let priceObj = {
             startTime: rows[i].StartTime,
             endTime: rows[i].EndTime,
-            price: price.toString().replace(/ /g, '').replace(/\,/g, '.') * 0.01
+            price: price.toString().replace(/ /g, '').replace(/(\d)\,/g, '.$1')
           }
           if (computePrices)
             oneDayPrices.push(computePrice(priceObj));


### PR DESCRIPTION
Correct MWH to kWh and currency fractional monetary unit conversion by collapsing the / 1000 (M to K) and * 100 (currency unit conversion) to just / 10, then implement this as part of the decimal separator conversion by shifting the position once left.