### PR TITLE
fix aidon list3

### DIFF
--- a/ams/aidon.js
+++ b/ams/aidon.js
@@ -124,10 +124,10 @@ async function listDecode(buf) {
         case "DATE":
           obj.data.timestamp = replaceChar(ts, 18, "0"); // Align the timestamp
           obj.data.meterDate = getAmsTime(msg.data, dataIndex);
-          obj.hourIndex = parseInt(obj.meterDate.substr(11, 2));
-          obj.isNewHour = obj.meterDate.substr(14, 5) === "00:10";
-          obj.isNewDay = obj.meterDate.substr(11, 8) === "00:00:10";
-          obj.isNewMonth = obj.meterDate.substr(8, 2) === "01" && obj.isNewDay;
+          obj.hourIndex = parseInt(obj.data.meterDate.substr(11, 2));
+          obj.isNewHour = obj.data.meterDate.substr(14, 5) === "00:10";
+          obj.isNewDay = obj.data.meterDate.substr(11, 8) === "00:00:10";
+          obj.isNewMonth = obj.data.meterDate.substr(8, 2) === "01" && obj.isNewDay;
 
           obj.listType = "list3";
           break;


### PR DESCRIPTION
Stop this from happening when creating list3 message: TypeError: Cannot read properties of undefined (reading 'substr')
    at listDecode (/app/ams/aidon.js:127:50)
    at EventEmitter.listHandler (/app/ams/aidon.js:167:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)